### PR TITLE
Ignoring unwanted validations

### DIFF
--- a/src/ValidationUnit.js
+++ b/src/ValidationUnit.js
@@ -84,6 +84,10 @@ export default class ValidationUnit {
     });
   }
 
+  shouldCheckValue(val) {
+    return this.hasIsRequired() || isCheckable(val);
+  }
+
   runValidation(value, allValues, name) {
     if (this.waiting && this.value === value) {
       return Promise.resolve(true);
@@ -92,7 +96,7 @@ export default class ValidationUnit {
     this.value = value;
     this.valid = undefined;
     this.messages = [];
-    if (!this.hasIsRequired() && !isCheckable(value)) {
+    if (!this.shouldCheckValue(value)) {
       return Promise.resolve(true).then(() => this.valid = true);
     }
 
@@ -118,8 +122,10 @@ export default class ValidationUnit {
 
   getState() {
     let {valid, messages, waiting} = this;
+    valid = (!this.shouldCheckValue(this.value)) ? true : valid;
     valid = (valid === undefined) ? valid :
       (waiting) ? undefined : valid;
+    console.log('returning state for', this);
     return {
       waiting: !!waiting,
       valid,
@@ -128,6 +134,7 @@ export default class ValidationUnit {
   }
 
   setState(valid, messages) {
+    console.log('setting state with', valid, messages);
     this.valid = !!valid;
     this.messages = messages;
   }

--- a/src/ValidationUnit.js
+++ b/src/ValidationUnit.js
@@ -33,7 +33,7 @@ let defaultFqdnOptions = {
 
 let requiredFunc = val => !!val;
 
-let isCheckable = val => !isUndefined(val) && !isNull(val) && val.toString().length;
+let isCheckable = val => !isUndefined(val) && !isNull(val) && !!val.toString().length;
 
 export default class ValidationUnit {
   constructor(...existing) {
@@ -122,10 +122,9 @@ export default class ValidationUnit {
 
   getState() {
     let {valid, messages, waiting} = this;
-    valid = (!this.shouldCheckValue(this.value)) ? true : valid;
+    valid = (!this.shouldCheckValue(this.value) && this.valid === undefined) ? true : valid;
     valid = (valid === undefined) ? valid :
       (waiting) ? undefined : valid;
-    console.log('returning state for', this);
     return {
       waiting: !!waiting,
       valid,
@@ -134,7 +133,6 @@ export default class ValidationUnit {
   }
 
   setState(valid, messages) {
-    console.log('setting state with', valid, messages);
     this.valid = !!valid;
     this.messages = messages;
   }

--- a/src/valour.js
+++ b/src/valour.js
@@ -72,6 +72,7 @@ class Valour {
   getResult(name) {
     let form = this.getForm(name);
     return Object.keys(form).reduce((result, key) => {
+      console.log('getting state for', key, form[key]);
       result[key] = form[key].getState();
       return result;
     }, {});
@@ -107,7 +108,7 @@ class Valour {
 
   isValid(name) {
     let result = this.getResult(name);
-    return !Object.keys(result).some((key) => !result[key].valid);
+    return !Object.keys(result).some((key) => (!result[key].valid));
   }
 
   setValidationState(name, data) {

--- a/src/valour.js
+++ b/src/valour.js
@@ -107,7 +107,7 @@ class Valour {
 
   isValid(name) {
     let result = this.getResult(name);
-    return !Object.keys(result).some((key) => (!result[key].valid));
+    return !Object.keys(result).some((key) => !result[key].valid);
   }
 
   setValidationState(name, data) {

--- a/src/valour.js
+++ b/src/valour.js
@@ -72,7 +72,6 @@ class Valour {
   getResult(name) {
     let form = this.getForm(name);
     return Object.keys(form).reduce((result, key) => {
-      console.log('getting state for', key, form[key]);
       result[key] = form[key].getState();
       return result;
     }, {});

--- a/test/ValidationUnit.specs.js
+++ b/test/ValidationUnit.specs.js
@@ -1393,4 +1393,20 @@ describe('ValidationUnit', () => {
       expect(unit.messages).to.equal(emptyArray);
     });
   });
+
+  describe('shouldCheckValue', () => {
+    beforeEach(() => {
+      unit = new ValidationUnit().isEmail();
+    });
+
+    it('returns false if the current ValidationUnit value is undefined, null or zero length', () => {
+      let isCheckable = unit.shouldCheckValue(undefined);
+      expect(isCheckable).to.be.false;
+    });
+
+    it('returns true if the current ValidationUnit should be evaluated', () => {
+      let isCheckable = unit.shouldCheckValue('working@email.com');
+      expect(isCheckable).to.be.true;
+    });
+  });
 });

--- a/test/ValidationUnit.specs.js
+++ b/test/ValidationUnit.specs.js
@@ -104,11 +104,79 @@ describe('ValidationUnit', () => {
       unit = unit.isEmail();
     });
 
-    it('is valid if the value is not checkable', (done) => {
+    it('is valid if the form value is not checkable', (done) => {
       unit.runValidation(null).then(() => {
         expect(unit.getState().valid).to.be.true;
         done();
       });
+    });
+  });
+
+  describe('shouldCheckValue', () => {
+    beforeEach(() => {
+      unit = new ValidationUnit().isEmail();
+    });
+
+    describe('when the value is not required', () => {
+      it('returns false if the current ValidationUnit value is undefined, null or zero length', () => {
+        let isCheckable = unit.shouldCheckValue(undefined);
+        expect(isCheckable).to.be.false;
+      });
+
+      it('returns true if the current ValidationUnit should be evaluated', () => {
+        let isCheckable = unit.shouldCheckValue('working@email.com');
+        expect(isCheckable).to.be.true;
+      });
+    });
+
+    describe('when the value is required', () => {
+      beforeEach(() => {
+        unit = new ValidationUnit().isEmail().isRequired();
+      });
+
+      it('always returns true', () => {
+        expect(unit.shouldCheckValue(null)).to.be.true;
+        expect(unit.shouldCheckValue('some value')).to.be.true;
+      });
+    });
+  });
+
+  describe('getState', () => {
+    beforeEach(() => {
+      unit = new ValidationUnit().isEmail();
+    });
+
+    it('sets valid to true if the current ValidationUnit is not required, the unit has no current value, and valid has no current value', () => {
+      unit.value = undefined;
+      unit.valid = undefined;
+      expect(unit.getState().valid).to.be.true;
+    });
+
+    it('valid keeps its current value if the unit has a current value', () => {
+      unit.value = 'anycurrentvalue';
+
+      unit.valid = undefined;
+      expect(unit.getState().valid).to.be.undefined;
+
+      unit.valid = false;
+      expect(unit.getState().valid).to.be.false;
+
+      unit.valid = true;
+      expect(unit.getState().valid).to.be.true;
+    });
+
+    it('valid keeps its current value if the ValidationUnit is required and the unit has no current value', () => {
+      unit = new ValidationUnit().isEmail().isRequired();
+      unit.value = undefined;
+
+      unit.valid = undefined;
+      expect(unit.getState().valid).to.be.undefined;
+
+      unit.valid = false;
+      expect(unit.getState().valid).to.be.false;
+
+      unit.valid = true;
+      expect(unit.getState().valid).to.be.true;
     });
   });
 
@@ -1391,22 +1459,6 @@ describe('ValidationUnit', () => {
       expect(unit.messages).to.be.null;
       unit.setState(null, emptyArray);
       expect(unit.messages).to.equal(emptyArray);
-    });
-  });
-
-  describe('shouldCheckValue', () => {
-    beforeEach(() => {
-      unit = new ValidationUnit().isEmail();
-    });
-
-    it('returns false if the current ValidationUnit value is undefined, null or zero length', () => {
-      let isCheckable = unit.shouldCheckValue(undefined);
-      expect(isCheckable).to.be.false;
-    });
-
-    it('returns true if the current ValidationUnit should be evaluated', () => {
-      let isCheckable = unit.shouldCheckValue('working@email.com');
-      expect(isCheckable).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Here's the bugfix addressing the issue regarding validation units returning false for validation when they are empty and not required. Also pulled out and logged errors from Promise-land.