### PR TITLE
Allow validation to be run synchronously

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .vimrc
 lib
+npm-debug.log

--- a/src/ValidationUnit.js
+++ b/src/ValidationUnit.js
@@ -121,6 +121,26 @@ export default class ValidationUnit {
              .then(removeWaiting);
   }
 
+  runValidationSync(value, allValues, name) {
+    this.value = value;
+    this.valid = undefined;
+
+    if (!this.shouldCheckValue(value)) {
+      this.valid = true;
+    }
+
+    const rules = this.rules.filter(rule => !rule.isAsync);
+    rules.forEach(rule => {
+      this.valid = rule.func(this.value);
+
+      if ( !this.valid ) {
+	this.messages.push(formatValidationMessage(rule.failureMessage, { name }));
+      }
+    });
+
+    this.setState(this.valid, this.messages);
+  }
+
   getState() {
     let {valid, messages, waiting} = this;
     valid = (!this.shouldCheckValue(this.value) && this.valid === undefined) ? true : valid;
@@ -150,7 +170,7 @@ export default class ValidationUnit {
                    forced = true,
                    isAsync = false
                   ) {
-    this.rules = [...this.rules, { forced, generator, name, isAsync }];
+    this.rules = [...this.rules, { func, failureMessage, forced, generator, name, isAsync }];
     return new ValidationUnit(this);
   }
 

--- a/src/valour.js
+++ b/src/valour.js
@@ -101,6 +101,16 @@ class Valour {
     });
   }
 
+  runValidationSync(name, data) {
+    let form = this.getForm(name);
+    Object.keys(form).forEach((key) => {
+      if (data[key] === undefined) {
+	return;
+      }
+      form[key].runValidationSync(data[key], data, key);
+    });
+  }
+
   forceValidation(name, data) {
     this.runValidation(name, data, true);
   }

--- a/test/valour.specs.js
+++ b/test/valour.specs.js
@@ -182,6 +182,20 @@ describe('validation', () => {
       });
     });
 
+    describe('runValidationSync', () => {
+      it('allows a result to be checked immediately after', (done) => {
+	valour.register('test', { name: valour.rule.isRequired() });
+	
+	valour.runValidationSync('test', {});
+	expect(valour.isValid('test')).to.be.false;
+	
+	valour.runValidationSync('test', { name: 'test' });
+	expect(valour.isValid('test')).to.be.true;
+	
+	done();
+      });
+    });
+
     describe('forceValidation', () => {
       it('updates with the current validation result. Unset fields are not checked.', (done) => {
         register((result) => {


### PR DESCRIPTION
Add a new function that affords the  ability for synchronous to be run
and immediately checked.