### PR TITLE
Add messages array to runValidationSync function

### DIFF
--- a/src/ValidationUnit.js
+++ b/src/ValidationUnit.js
@@ -124,6 +124,7 @@ export default class ValidationUnit {
   runValidationSync(value, allValues, name) {
     this.value = value;
     this.valid = undefined;
+    this.messages = [];
 
     if (!this.shouldCheckValue(value)) {
       this.valid = true;


### PR DESCRIPTION
Messages cannot be added to an array that does not exist on the
object. Set up the array when running synchronous validation.