### PR TITLE
Ensure stacked validation rules work when synced

### DIFF
--- a/src/ValidationUnit.js
+++ b/src/ValidationUnit.js
@@ -131,15 +131,22 @@ export default class ValidationUnit {
     }
 
     const rules = this.rules.filter(rule => !rule.isAsync);
-    rules.forEach(rule => {
-      this.valid = rule.func(this.value);
+    const ruleViolationStatuses = rules.map(rule => {
+      const isValid = rule.func(this.value);
+      return {
+	rule,
+	isValid
+      };
+    });
+    ruleViolationStatuses.forEach(violationStatus => {
+      const { isValid, rule } = violationStatus;
 
-      if ( !this.valid ) {
-	this.messages.push(formatValidationMessage(rule.failureMessage, { name }));
+      if ( !isValid && rule.failureMessage ) {
+        this.messages.push(formatValidationMessage(rule.failureMessage, { name }));
       }
     });
-
-    this.setState(this.valid, this.messages);
+    const allRulesSatisfied = ruleViolationStatuses.every(status => status.isValid);
+    this.setState(allRulesSatisfied, this.messages);
   }
 
   getState() {

--- a/test/valour.specs.js
+++ b/test/valour.specs.js
@@ -184,15 +184,34 @@ describe('validation', () => {
 
     describe('runValidationSync', () => {
       it('allows a result to be checked immediately after', (done) => {
-	valour.register('test', { name: valour.rule.isRequired() });
-	
-	valour.runValidationSync('test', {});
-	expect(valour.isValid('test')).to.be.false;
-	
-	valour.runValidationSync('test', { name: 'test' });
-	expect(valour.isValid('test')).to.be.true;
-	
-	done();
+        valour.register('test', { name: valour.rule.isRequired() });
+
+        valour.runValidationSync('test', {});
+        expect(valour.isValid('test')).to.be.false;
+
+        valour.runValidationSync('test', { name: 'test' });
+        expect(valour.isValid('test')).to.be.true;
+
+        done();
+      });
+
+      it('returns false if a single validation fails in validation chain', (done) => {
+	let rule = valour.rule
+                         .isValidatedBy(val => val.length >= 3)
+                         .isValidatedBy(val => val.length <= 50);
+        valour.register('test', {
+          name: rule
+        });
+
+        valour.runValidationSync('test', { name: 'abcdefghijklmnopqrstuvwxyzabcdefghijsdfasdfsdfasdfasdfklmnopqrstuvwxyaldkjfadf' });
+        expect(valour.isValid('test')).to.be.false;
+
+        valour.runValidationSync('test', { name: 'Ip' });
+        expect(valour.isValid('test')).to.be.false;
+
+        valour.runValidationSync('test', { name: 'I work!' });
+        expect(valour.isValid('test')).to.be.true;
+        done();
       });
     });
 


### PR DESCRIPTION
When multiple validation rules are defined, but only one is violated,
it's possible that the validation status can get overwritten. For
example, if I have two rules:
- string must be greater than 3 characters
- string must be less than 50 characters

If the second rule is valid, such as 'Hi' - it will pass validation even
though it would fail the first rule.

This tests to make sure that all rules are satisfied when running
syncronously and fails if any of the rules are violated.